### PR TITLE
Multipart before_upload option for upload method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 dist: trusty
 language: php
-sudo: false
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+matrix:
+  include:
+    - php: 5.6
+      dist: xenial
+    - php: 7.0
+      dist: xenial
+    - php: 7.1
+      dist: bionic
+    - php: 7.2
+      dist: bionic
+    - php: 7.3
+      dist: bionic
+    - php: 7.4
+      dist: bionic
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.25 - 2020-06-02
+
+* Use `S3Client::encodeKey` for key encoding.
+
+## 1.0.24 - 2020-02-23
+
+* Depend on S3ClientInterface rather than the concrete client.
+
 ## 1.0.23 - 2019-06-05
 
 * Prevent content type detection for directory creation.

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ composer require league/flysystem-aws-s3-v3
 
 # Bootstrap
 
+Using standard `Aws\S3\S3Client`:
+
 ``` php
 <?php
 use Aws\S3\S3Client;
@@ -32,6 +34,28 @@ $client = new S3Client([
         'secret' => 'your-secret'
     ],
     'region' => 'your-region',
+    'version' => 'latest|version',
+]);
+
+$adapter = new AwsS3Adapter($client, 'your-bucket-name');
+$filesystem = new Filesystem($adapter);
+```
+
+or using `Aws\S3\S3MultiRegionClient` which does not require to specify the `region` parameter:
+
+``` php
+<?php
+use Aws\S3\S3MultiRegionClient;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Filesystem;
+
+include __DIR__ . '/vendor/autoload.php';
+
+$client = new S3MultiRegionClient([
+    'credentials' => [
+        'key'    => 'your-key',
+        'secret' => 'your-secret'
+    ],
     'version' => 'latest|version',
 ]);
 

--- a/spec/AwsS3AdapterSpec.php
+++ b/spec/AwsS3AdapterSpec.php
@@ -7,6 +7,7 @@ use Aws\Result;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
+use Aws\S3\S3Client;
 use GuzzleHttp\Psr7;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
@@ -624,7 +625,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
+            'CopySource' => S3Client::encodeKey($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => $acl,
         ])->willReturn($copyCommand);
 
@@ -648,7 +649,7 @@ class AwsS3AdapterSpec extends ObjectBehavior
         $this->client->getCommand('copyObject', [
             'Bucket' => $this->bucket,
             'Key' => self::PATH_PREFIX.'/'.$key,
-            'CopySource' => urlencode($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
+            'CopySource' => S3Client::encodeKey($this->bucket.'/'.self::PATH_PREFIX.'/'.$sourceKey),
             'ACL' => 'private',
         ])->willReturn($command);
 

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -593,6 +593,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         $acl = array_key_exists('ACL', $options) ? $options['ACL'] : 'private';
 
         // Multipart options
+        $before_upload = array_key_exists('before_upload', $options) ? $options['before_upload'] : null;
         $concurrency = array_key_exists('concurrency', $options) ? $options['concurrency'] : null;
         $mup_threshold = array_key_exists('mup_threshold', $options) ? $options['mup_threshold'] : null;
         $part_size = array_key_exists('part_size', $options) ? $options['part_size'] : null;
@@ -613,6 +614,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 
         try {
             $this->s3Client->upload($this->bucket, $key, $body, $acl, [
+                'before_upload' => $before_upload,
                 'concurrency' => $concurrency,
                 'mup_threshold' => $mup_threshold,
                 'part_size' => $part_size,

--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -7,9 +7,10 @@ use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\Exception\S3MultipartUploadException;
 use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Adapter\CanOverwriteFiles;
-use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use League\Flysystem\Util;
 
@@ -59,7 +60,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     ];
 
     /**
-     * @var S3Client
+     * @var S3ClientInterface
      */
     protected $s3Client;
 
@@ -76,12 +77,12 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Constructor.
      *
-     * @param S3Client $client
+     * @param S3ClientInterface $client
      * @param string   $bucket
      * @param string   $prefix
      * @param array    $options
      */
-    public function __construct(S3Client $client, $bucket, $prefix = '', array $options = [])
+    public function __construct(S3ClientInterface $client, $bucket, $prefix = '', array $options = [])
     {
         $this->s3Client = $client;
         $this->bucket = $bucket;
@@ -112,7 +113,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Get the S3Client instance.
      *
-     * @return S3Client
+     * @return S3ClientInterface
      */
     public function getClient()
     {
@@ -421,7 +422,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             [
                 'Bucket'     => $this->bucket,
                 'Key'        => $this->applyPathPrefix($newpath),
-                'CopySource' => rawurlencode($this->bucket . '/' . $this->applyPathPrefix($path)),
+                'CopySource' => S3Client::encodeKey($this->bucket . '/' . $this->applyPathPrefix($path)),
                 'ACL'        => $this->getRawVisibility($path) === AdapterInterface::VISIBILITY_PUBLIC
                     ? 'public-read' : 'private',
             ] + $this->options
@@ -458,7 +459,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Read an object and normalize the response.
      *
-     * @param $path
+     * @param string $path
      *
      * @return array|bool
      */
@@ -580,9 +581,9 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     /**
      * Upload an object.
      *
-     * @param        $path
-     * @param        $body
-     * @param Config $config
+     * @param string          $path
+     * @param string|resource $body
+     * @param Config          $config
      *
      * @return array|bool
      */
@@ -631,6 +632,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
      * Check if the path contains only directories
      *
      * @param string $path
+     *
      * @return bool
      */
     private function isOnlyDir($path)
@@ -705,7 +707,7 @@ class AwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     }
 
     /**
-     * @param $location
+     * @param string $location
      *
      * @return bool
      */


### PR DESCRIPTION
Adds `before_upload` multipart option ([see Aws\S3\ObjectUploader](https://github.com/aws/aws-sdk-php/blob/3.141.0/src/S3/ObjectUploader.php#L23))

Related to:
https://github.com/thephpleague/flysystem-aws-s3-v3/pull/183#discussion_r438410118
https://github.com/thephpleague/flysystem-aws-s3-v3/pull/183#discussion_r438410369